### PR TITLE
Default filetype detection may need to be disabled

### DIFF
--- a/ftdetect/logfile.vim
+++ b/ftdetect/logfile.vim
@@ -10,5 +10,5 @@ function! s:neomutt_log()
 		return
 	endif
 
-	set filetype=neomuttlog
+	setfiletype neomuttlog
 endfunction

--- a/ftdetect/mail.vim
+++ b/ftdetect/mail.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead neomutt-*-\w\+,neomutt[[:alnum:]_-]\\\{6\} set filetype=mail
+au BufNewFile,BufRead neomutt-*-\w\+,neomutt[[:alnum:]_-]\\\{6\} setfiletype mail

--- a/ftdetect/neomuttrc.vim
+++ b/ftdetect/neomuttrc.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead [Nn]eomuttrc,.neomuttrc,.neomutt/*muttrc,.config/neomutt/*muttrc set filetype=neomuttrc
+au BufNewFile,BufRead [Nn]eomuttrc,.neomuttrc,.neomutt/*muttrc,.config/neomutt/*muttrc setfiletype neomuttrc


### PR DESCRIPTION
Hey,

Sometimes I write mails in HTML and when I edit an HTML attachment in mutt, I want the right filetype to be detected, according to the contents of the file, not it's path.

If I had neomutt.vim installed manually i.e [this plugin's file `ftdetect/mail.vim`](https://github.com/neomutt/neomutt.vim/blob/82fded4ea26ec3271aa14308221bb4b76304539f/ftdetect/mail.vim) was under my own `runtimepath`, I would have just changed this file to something like this:

```vim
au BufNewFile,BufRead neomutt-*-\w\+,neomutt[[:alnum:]_-]\\\{6\} if getline(1) =~# '^<DOCTYPE html' | set filetype=html | else | set filetype=mail | endif
```

But that's not elegant at all because I prefer to keep plugin as they are.

I've also tried to put the following straight in my `init.vim` and it didn't help either:

```vim
au FileType neomutt-*-\w\+,neomutt[[:alnum:]_-]\\\{6\} if getline(1) =~# '^<DOCTYPE html' | set filetype=html | endif
```

Please tell me if I'm missing a specific essential Vim feature. Otherwise, I see these change nescessary. I've updated `doc/neomutt.txt` as well.

Thanks in advance.