### PR TITLE
Enable spell checking in "trailing comments"

### DIFF
--- a/syntax/neomuttrc.vim
+++ b/syntax/neomuttrc.vim
@@ -22,7 +22,7 @@ setlocal isk=@,48-57,_,-
 syntax match muttrcComment	"^# .*$" contains=@Spell
 syntax match muttrcComment	"^#[^ ].*$"
 syntax match muttrcComment	"^#$"
-syntax match muttrcComment	"[^\\]#.*$"lc=1
+syntax match muttrcComment	"[^\\]#.*$"lc=1 contains=@Spell
 
 " Escape sequences (back-tick and pipe goes here too)
 syntax match muttrcEscape	+\\[#tnr"'Cc ]+


### PR DESCRIPTION
Enable spell checking in "trailing comments".  A trailing comment is this:

    # I'm not a "trailing comment" as I'm alone on this line.
    set quit = no # Neomutt is so good, you should never want to leave